### PR TITLE
Redesign authentication pages with landing page styling

### DIFF
--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -1,0 +1,258 @@
+/* Auth Pages Container */
+.auth-container {
+  background: linear-gradient(135deg, #1a5f5f 0%, #2a7f7f 50%, #1a5f5f 100%);
+  background-attachment: fixed;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+.auth-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: 
+    radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.05) 0%, transparent 50%);
+  pointer-events: none;
+}
+
+.auth-content {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 450px;
+}
+
+/* Auth Card */
+.auth-card {
+  background: white;
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.auth-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+}
+
+.auth-card-header {
+  background: linear-gradient(135deg, #1a5f5f 0%, #2a7f7f 100%);
+  color: white;
+  padding: 30px 20px;
+  text-align: center;
+}
+
+.auth-card-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  color: white;
+}
+
+.auth-card-subtitle {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.9);
+  margin-top: 8px;
+  font-weight: 300;
+}
+
+/* Form Styling */
+.auth-form-group {
+  margin-bottom: 20px;
+}
+
+.auth-form-label {
+  font-weight: 600;
+  color: #1a5f5f;
+  margin-bottom: 8px;
+  display: block;
+  font-size: 0.95rem;
+}
+
+.auth-form-input {
+  width: 100%;
+  padding: 12px 15px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  color: #333;
+}
+
+.auth-form-input:focus {
+  outline: none;
+  border-color: #20a084;
+  box-shadow: 0 0 0 3px rgba(32, 160, 132, 0.1);
+}
+
+.auth-form-input.is-invalid {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
+}
+
+.auth-form-input::placeholder {
+  color: #999;
+}
+
+/* Error Messages */
+.auth-error-message {
+  color: #dc3545;
+  font-size: 0.85rem;
+  margin-top: 5px;
+  display: block;
+}
+
+.auth-error-alert {
+  background-color: #f8d7da;
+  border: 2px solid #dc3545;
+  color: #721c24;
+  padding: 12px 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 0.95rem;
+}
+
+/* Remember Me Checkbox */
+.auth-checkbox-group {
+  display: flex;
+  align-items: center;
+  margin: 15px 0 25px 0;
+}
+
+.auth-checkbox-input {
+  width: 18px;
+  height: 18px;
+  margin-right: 8px;
+  cursor: pointer;
+  accent-color: #20a084;
+}
+
+.auth-checkbox-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #333;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Submit Button */
+.auth-submit-button {
+  width: 100%;
+  padding: 14px;
+  background-color: #20a084;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.1s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.auth-submit-button:hover:not(:disabled) {
+  background-color: #1a8a6b;
+  transform: translateY(-1px);
+}
+
+.auth-submit-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.auth-submit-button:disabled {
+  background-color: #999;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Loading Spinner */
+.auth-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Links */
+.auth-link {
+  color: #20a084;
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.3s ease;
+}
+
+.auth-link:hover {
+  color: #1a8a6b;
+  text-decoration: underline;
+}
+
+/* Footer */
+.auth-card-footer {
+  background-color: #f8f9fa;
+  padding: 15px 20px;
+  text-align: center;
+  border-top: 1px solid #e0e0e0;
+  font-size: 0.95rem;
+  color: #666;
+}
+
+.auth-card-footer a {
+  margin-left: 5px;
+}
+
+/* Divider */
+.auth-divider {
+  text-align: center;
+  margin: 25px 0;
+  color: #999;
+  font-size: 0.9rem;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex-grow: 1;
+  background: #e0e0e0;
+  height: 1px;
+  display: inline-block;
+  width: auto;
+}
+
+/* Responsive */
+@media (max-width: 576px) {
+  .auth-content {
+    max-width: 100%;
+  }
+
+  .auth-card-title {
+    font-size: 1.5rem;
+  }
+
+  .auth-submit-button {
+    padding: 12px;
+    font-size: 0.95rem;
+  }
+}

--- a/src/app/auth/change-password/page.tsx
+++ b/src/app/auth/change-password/page.tsx
@@ -3,32 +3,34 @@
 import { useForm } from 'react-hook-form';
 import { useSession } from 'next-auth/react'; // v5 compatible
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useState } from 'react';
 import * as Yup from 'yup';
 import swal from 'sweetalert';
-import { Card, Col, Container, Button, Form, Row } from 'react-bootstrap';
 import { changePassword } from '@/lib/dbActions';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import '../auth.css';
 
 type ChangePasswordForm = {
   oldpassword: string;
   password: string;
   confirmPassword: string;
-  // acceptTerms: boolean;
 };
 
 /** The change password page. */
 const ChangePassword = () => {
   const { data: session, status } = useSession();
   const email = session?.user?.email || '';
+  const [isLoading, setIsLoading] = useState(false);
+
   const validationSchema = Yup.object().shape({
-    oldpassword: Yup.string().required('Password is required'),
+    oldpassword: Yup.string().required('Current password is required'),
     password: Yup.string()
-      .required('Password is required')
+      .required('New password is required')
       .min(6, 'Password must be at least 6 characters')
       .max(40, 'Password must not exceed 40 characters'),
     confirmPassword: Yup.string()
       .required('Confirm Password is required')
-      .oneOf([Yup.ref('password'), ''], 'Confirm Password does not match'),
+      .oneOf([Yup.ref('password'), ''], 'Passwords do not match'),
   });
 
   const {
@@ -41,10 +43,21 @@ const ChangePassword = () => {
   });
 
   const onSubmit = async (data: ChangePasswordForm) => {
-    // console.log(JSON.stringify(data, null, 2));
-    await changePassword({ email, ...data });
-    await swal('Password Changed', 'Your password has been changed', 'success', { timer: 2000 });
-    reset();
+    try {
+      setIsLoading(true);
+      await changePassword({ email, ...data });
+      await swal(
+        'Success',
+        'Your password has been changed successfully',
+        'success',
+        { timer: 2000 }
+      );
+      reset();
+    } catch (error) {
+      await swal('Error', 'Failed to change password', 'error');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (status === 'loading') {
@@ -52,62 +65,98 @@ const ChangePassword = () => {
   }
 
   return (
-    <main>
-      <Container>
-        <Row className="justify-content-center">
-          <Col xs={5}>
-            <h1 className="text-center">Change Password</h1>
-            <Card>
-              <Card.Body>
-                <Form onSubmit={handleSubmit(onSubmit)}>
-                  <Form.Group className="form-group">
-                    <Form.Label>Old Passord</Form.Label>
-                    <input
-                      type="password"
-                      {...register('oldpassword')}
-                      className={`form-control ${errors.oldpassword ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.oldpassword?.message}</div>
-                  </Form.Group>
+    <main className="auth-container">
+      <div className="auth-content">
+        <div className="auth-card">
+          <div className="auth-card-header">
+            <h1 className="auth-card-title">Change Password</h1>
+            <p className="auth-card-subtitle">Update your security settings</p>
+          </div>
 
-                  <Form.Group className="form-group">
-                    <Form.Label>New Password</Form.Label>
-                    <input
-                      type="password"
-                      {...register('password')}
-                      className={`form-control ${errors.password ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.password?.message}</div>
-                  </Form.Group>
-                  <Form.Group className="form-group">
-                    <Form.Label>Confirm Password</Form.Label>
-                    <input
-                      type="password"
-                      {...register('confirmPassword')}
-                      className={`form-control ${errors.confirmPassword ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.confirmPassword?.message}</div>
-                  </Form.Group>
-                  <Form.Group className="form-group py-3">
-                    <Row>
-                      <Col>
-                        <Button type="submit" className="btn btn-primary">
-                          Change
-                        </Button>
-                      </Col>
-                      <Col>
-                        <Button type="button" onClick={() => reset()} className="btn btn-warning float-right">
-                          Reset
-                        </Button>
-                      </Col>
-                    </Row>
-                  </Form.Group>
-                </Form>
-              </Card.Body>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
+          <form onSubmit={handleSubmit(onSubmit)} style={{ padding: '30px' }}>
+            <div className="auth-form-group">
+              <label className="auth-form-label">Current Password</label>
+              <input
+                type="password"
+                {...register('oldpassword')}
+                className={`auth-form-input ${errors.oldpassword ? 'is-invalid' : ''}`}
+                placeholder="Enter your current password"
+                disabled={isLoading}
+                autoComplete="current-password"
+              />
+              {errors.oldpassword && (
+                <span className="auth-error-message">{errors.oldpassword.message}</span>
+              )}
+            </div>
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">New Password</label>
+              <input
+                type="password"
+                {...register('password')}
+                className={`auth-form-input ${errors.password ? 'is-invalid' : ''}`}
+                placeholder="Min. 6 characters"
+                disabled={isLoading}
+                autoComplete="new-password"
+              />
+              {errors.password && (
+                <span className="auth-error-message">{errors.password.message}</span>
+              )}
+            </div>
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Confirm New Password</label>
+              <input
+                type="password"
+                {...register('confirmPassword')}
+                className={`auth-form-input ${
+                  errors.confirmPassword ? 'is-invalid' : ''
+                }`}
+                placeholder="Re-enter your new password"
+                disabled={isLoading}
+                autoComplete="new-password"
+              />
+              {errors.confirmPassword && (
+                <span className="auth-error-message">
+                  {errors.confirmPassword.message}
+                </span>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px', marginTop: '25px' }}>
+              <button
+                type="submit"
+                className="auth-submit-button"
+                style={{ flex: 1 }}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <span className="auth-spinner" />
+                    Updating...
+                  </>
+                ) : (
+                  'Change Password'
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  reset();
+                }}
+                className="auth-submit-button"
+                style={{
+                  flex: 1,
+                  backgroundColor: '#999',
+                }}
+                disabled={isLoading}
+              >
+                Clear
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
     </main>
   );
 };

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,55 +1,141 @@
 'use client';
 
 import { signIn } from 'next-auth/react'; // v5 compatible
-import { Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
+import { useRouter } from 'next/navigation';
+import { useState, FormEvent, useRef, useEffect } from 'react';
+import '../auth.css';
 
 /** The sign in page. */
 const SignIn = () => {
-  const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
+  const router = useRouter();
+  const [error, setError] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+
+  // Load saved email if "Remember me" was checked before
+  useEffect(() => {
+    const savedEmail = localStorage.getItem('rememberedEmail');
+    if (savedEmail && emailRef.current) {
+      emailRef.current.value = savedEmail;
+      setRememberMe(true);
+    }
+  }, []);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const target = e.target as typeof e.target & {
-      email: { value: string };
-      password: { value: string };
-    };
-    const email = target.email.value;
-    const password = target.password.value;
-    await signIn('credentials', {
-      callbackUrl: '/list',
+    setError('');
+    setIsLoading(true);
+
+    const email = emailRef.current?.value || '';
+    const password = passwordRef.current?.value || '';
+
+    // Basic validation
+    if (!email || !password) {
+      setError('Please enter both email and password');
+      setIsLoading(false);
+      return;
+    }
+
+    // Save email if remember me is checked
+    if (rememberMe) {
+      localStorage.setItem('rememberedEmail', email);
+    } else {
+      localStorage.removeItem('rememberedEmail');
+    }
+
+    const result = await signIn('credentials', {
       email,
       password,
+      redirect: false,
     });
+
+    if (result?.error) {
+      setError('Invalid email or password. Please try again.');
+      setIsLoading(false);
+    } else if (result?.ok) {
+      // Success - redirect to list page
+      router.push('/list');
+    }
   };
 
   return (
-    <main>
-      <Container>
-        <Row className="justify-content-center">
-          <Col xs={5}>
-            <h1 className="text-center">Sign In</h1>
-            <Card>
-              <Card.Body>
-                <Form method="post" onSubmit={handleSubmit}>
-                  <Form.Group controlId="formBasicEmail">
-                    <Form.Label>Email</Form.Label>
-                    <input name="email" type="text" className="form-control" />
-                  </Form.Group>
-                  <Form.Group>
-                    <Form.Label>Password</Form.Label>
-                    <input name="password" type="password" className="form-control" />
-                  </Form.Group>
-                  <Button type="submit" className="mt-3">
-                    Signin
-                  </Button>
-                </Form>
-              </Card.Body>
-              <Card.Footer>
-                Don&apos;t have an account?
-                <a href="/auth/signup">Sign up</a>
-              </Card.Footer>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
+    <main className="auth-container">
+      <div className="auth-content">
+        <div className="auth-card">
+          <div className="auth-card-header">
+            <h1 className="auth-card-title">Sign In</h1>
+            <p className="auth-card-subtitle">Welcome back to Mānoa CourseWise</p>
+          </div>
+
+          <form onSubmit={handleSubmit} style={{ padding: '30px' }}>
+            {error && <div className="auth-error-alert">{error}</div>}
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Email Address</label>
+              <input
+                ref={emailRef}
+                name="email"
+                type="email"
+                className="auth-form-input"
+                placeholder="you@example.com"
+                disabled={isLoading}
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Password</label>
+              <input
+                ref={passwordRef}
+                name="password"
+                type="password"
+                className="auth-form-input"
+                placeholder="Enter your password"
+                disabled={isLoading}
+                autoComplete="current-password"
+              />
+            </div>
+
+            <div className="auth-checkbox-group">
+              <input
+                type="checkbox"
+                id="rememberMe"
+                className="auth-checkbox-input"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                disabled={isLoading}
+              />
+              <label htmlFor="rememberMe" className="auth-checkbox-label">
+                Remember me
+              </label>
+            </div>
+
+            <button
+              type="submit"
+              className="auth-submit-button"
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <>
+                  <span className="auth-spinner" />
+                  Signing in...
+                </>
+              ) : (
+                'Sign In'
+              )}
+            </button>
+          </form>
+
+          <div className="auth-card-footer">
+            Don&apos;t have an account?{' '}
+            <a href="/auth/signup" className="auth-link">
+              Sign up
+            </a>
+          </div>
+        </div>
+      </div>
     </main>
   );
 };

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -19,7 +19,6 @@ const SignIn = () => {
     const savedEmail = localStorage.getItem('rememberedEmail');
     if (savedEmail && emailRef.current) {
       emailRef.current.value = savedEmail;
-      setRememberMe(true);
     }
   }, []);
 

--- a/src/app/auth/signout/page.tsx
+++ b/src/app/auth/signout/page.tsx
@@ -1,27 +1,57 @@
 'use client';
 
 import { signOut } from 'next-auth/react'; // v5 compatible
-import { Button, Col, Row } from 'react-bootstrap';
+import { useRouter } from 'next/navigation';
+import '../auth.css';
 
-/** After the user clicks the "SignOut" link in the NavBar, log them out and display this page. */
-const SignOut = () => (
-  <Col id="signout-page" className="text-center py-3">
-    <h2>Do you want to sign out?</h2>
-    <Row>
-      <Col xs={4} />
-      <Col>
-        <Button variant="danger" onClick={() => signOut({ callbackUrl: '/', redirect: true })}>
-          Sign Out
-        </Button>
-      </Col>
-      <Col>
-        <Button variant="secondary" href="/">
-          Cancel
-        </Button>
-      </Col>
-      <Col xs={4} />
-    </Row>
-  </Col>
-);
+/** Confirmation page before signing out. */
+const SignOut = () => {
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await signOut({ redirect: false });
+    router.push('/');
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  return (
+    <main className="auth-container">
+      <div className="auth-content">
+        <div className="auth-card">
+          <div className="auth-card-header">
+            <h1 className="auth-card-title">Sign Out</h1>
+            <p className="auth-card-subtitle">Are you sure you want to leave?</p>
+          </div>
+
+          <div style={{ padding: '30px', textAlign: 'center' }}>
+            <p style={{ color: '#666', marginBottom: '30px', fontSize: '1rem' }}>
+              You will be signed out of your account and redirected to the home page.
+            </p>
+
+            <div style={{ display: 'flex', gap: '10px' }}>
+              <button
+                onClick={handleSignOut}
+                className="auth-submit-button"
+                style={{ flex: 1, backgroundColor: '#dc3545' }}
+              >
+                Sign Out
+              </button>
+              <button
+                onClick={handleCancel}
+                className="auth-submit-button"
+                style={{ flex: 1, backgroundColor: '#6c757d' }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};
 
 export default SignOut;

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -3,19 +3,24 @@
 import { signIn } from 'next-auth/react'; // v5 compatible
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useState } from 'react';
 import * as Yup from 'yup';
-import { Card, Col, Container, Button, Form, Row } from 'react-bootstrap';
+import { useRouter } from 'next/navigation';
 import { createUser } from '@/lib/dbActions';
+import '../auth.css';
 
 type SignUpForm = {
   email: string;
   password: string;
   confirmPassword: string;
-  // acceptTerms: boolean;
 };
 
 /** The sign up page. */
 const SignUp = () => {
+  const router = useRouter();
+  const [error, setError] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+
   const validationSchema = Yup.object().shape({
     email: Yup.string().required('Email is required').email('Email is invalid'),
     password: Yup.string()
@@ -37,73 +42,136 @@ const SignUp = () => {
   });
 
   const onSubmit = async (data: SignUpForm) => {
-    // console.log(JSON.stringify(data, null, 2));
-    await createUser(data);
-    // After creating, signIn with redirect to the add page
-    await signIn('credentials', { callbackUrl: '/add', ...data });
+    try {
+      setIsLoading(true);
+      setError('');
+
+      // Create the user
+      await createUser(data);
+
+      // Sign in after successful creation
+      const result = await signIn('credentials', {
+        email: data.email,
+        password: data.password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        setError('Account created but sign in failed. Please try signing in manually.');
+        setIsLoading(false);
+      } else if (result?.ok) {
+        // Redirect to add page
+        router.push('/add');
+      }
+    } catch (err) {
+      setError('An error occurred during sign up. Please try again.');
+      setIsLoading(false);
+    }
   };
 
   return (
-    <main>
-      <Container>
-        <Row className="justify-content-center">
-          <Col xs={5}>
-            <h1 className="text-center">Sign Up</h1>
-            <Card>
-              <Card.Body>
-                <Form onSubmit={handleSubmit(onSubmit)}>
-                  <Form.Group className="form-group">
-                    <Form.Label>Email</Form.Label>
-                    <input
-                      type="text"
-                      {...register('email')}
-                      className={`form-control ${errors.email ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.email?.message}</div>
-                  </Form.Group>
+    <main className="auth-container">
+      <div className="auth-content">
+        <div className="auth-card">
+          <div className="auth-card-header">
+            <h1 className="auth-card-title">Create Account</h1>
+            <p className="auth-card-subtitle">Join Mānoa CourseWise today</p>
+          </div>
 
-                  <Form.Group className="form-group">
-                    <Form.Label>Password</Form.Label>
-                    <input
-                      type="password"
-                      {...register('password')}
-                      className={`form-control ${errors.password ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.password?.message}</div>
-                  </Form.Group>
-                  <Form.Group className="form-group">
-                    <Form.Label>Confirm Password</Form.Label>
-                    <input
-                      type="password"
-                      {...register('confirmPassword')}
-                      className={`form-control ${errors.confirmPassword ? 'is-invalid' : ''}`}
-                    />
-                    <div className="invalid-feedback">{errors.confirmPassword?.message}</div>
-                  </Form.Group>
-                  <Form.Group className="form-group py-3">
-                    <Row>
-                      <Col>
-                        <Button type="submit" className="btn btn-primary">
-                          Register
-                        </Button>
-                      </Col>
-                      <Col>
-                        <Button type="button" onClick={() => reset()} className="btn btn-warning float-right">
-                          Reset
-                        </Button>
-                      </Col>
-                    </Row>
-                  </Form.Group>
-                </Form>
-              </Card.Body>
-              <Card.Footer>
-                Already have an account?
-                <a href="/auth/signin">Sign in</a>
-              </Card.Footer>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
+          <form onSubmit={handleSubmit(onSubmit)} style={{ padding: '30px' }}>
+            {error && <div className="auth-error-alert">{error}</div>}
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Email Address</label>
+              <input
+                type="email"
+                {...register('email')}
+                className={`auth-form-input ${errors.email ? 'is-invalid' : ''}`}
+                placeholder="you@example.com"
+                disabled={isLoading}
+                autoComplete="email"
+              />
+              {errors.email && (
+                <span className="auth-error-message">{errors.email.message}</span>
+              )}
+            </div>
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Password</label>
+              <input
+                type="password"
+                {...register('password')}
+                className={`auth-form-input ${errors.password ? 'is-invalid' : ''}`}
+                placeholder="Min. 6 characters"
+                disabled={isLoading}
+                autoComplete="new-password"
+              />
+              {errors.password && (
+                <span className="auth-error-message">{errors.password.message}</span>
+              )}
+            </div>
+
+            <div className="auth-form-group">
+              <label className="auth-form-label">Confirm Password</label>
+              <input
+                type="password"
+                {...register('confirmPassword')}
+                className={`auth-form-input ${
+                  errors.confirmPassword ? 'is-invalid' : ''
+                }`}
+                placeholder="Re-enter your password"
+                disabled={isLoading}
+                autoComplete="new-password"
+              />
+              {errors.confirmPassword && (
+                <span className="auth-error-message">
+                  {errors.confirmPassword.message}
+                </span>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px', marginTop: '25px' }}>
+              <button
+                type="submit"
+                className="auth-submit-button"
+                style={{ flex: 1 }}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <span className="auth-spinner" />
+                    Creating account...
+                  </>
+                ) : (
+                  'Create Account'
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  reset();
+                  setError('');
+                }}
+                className="auth-submit-button"
+                style={{
+                  flex: 1,
+                  backgroundColor: '#999',
+                }}
+                disabled={isLoading}
+              >
+                Clear
+              </button>
+            </div>
+          </form>
+
+          <div className="auth-card-footer">
+            Already have an account?{' '}
+            <a href="/auth/signin" className="auth-link">
+              Sign in
+            </a>
+          </div>
+        </div>
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
- Create new auth.css with teal/green design system matching landing page
- Update sign-in page with error handling, loading states, 'Remember me' checkbox
- Update sign-up page with matching styling and better error messages
- Update sign-out page with improved confirmation UI
- Update change-password page with consistent styling
- All auth pages now use same design language for cohesive user experience